### PR TITLE
0.3.1 - Fix OvenBlockEntity causing tick lag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.7
 
 # Mod Properties
-mod_version=0.3.0+1.20.1
+mod_version=0.3.1+1.20.1
 maven_group=com.zombie_cute.mc.bakingdelight
 archives_base_name=bakingdelight
 

--- a/src/main/java/com/zombie_cute/mc/bakingdelight/block/entities/OvenBlockEntity.java
+++ b/src/main/java/com/zombie_cute/mc/bakingdelight/block/entities/OvenBlockEntity.java
@@ -4,7 +4,9 @@ import com.zombie_cute.mc.bakingdelight.block.ModBlockEntities;
 import com.zombie_cute.mc.bakingdelight.item.ModItems;
 import com.zombie_cute.mc.bakingdelight.recipe.BakingRecipe;
 import com.zombie_cute.mc.bakingdelight.screen.OvenScreenHandler;
+import net.fabricmc.fabric.api.registry.FuelRegistry;
 import net.fabricmc.fabric.api.screenhandler.v1.ExtendedScreenHandlerFactory;
+import net.fabricmc.fabric.impl.content.registry.FuelRegistryImpl;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.block.entity.BlockEntity;
@@ -172,14 +174,14 @@ public class OvenBlockEntity extends BlockEntity implements ExtendedScreenHandle
         }
     }
     public static boolean canUseAsFuel(ItemStack stack) {
-        return AbstractFurnaceBlockEntity.createFuelTimeMap().containsKey(stack.getItem());
+        return FuelRegistry.INSTANCE.get(stack.getItem()) != null;
     }
     private int getFuelTime(ItemStack fuel){
         if (fuel.isEmpty()) {
             return 0;
         }
-        Item item = fuel.getItem();
-        return AbstractFurnaceBlockEntity.createFuelTimeMap().getOrDefault(item, 0);
+        Integer time = FuelRegistry.INSTANCE.get(fuel.getItem());
+        return  time == null ? 0 : time;
     }
 
     private boolean isFuelBurning() {


### PR DESCRIPTION
# Fixes: 
`OvenBlockEntity` causing significant server thread tick lag, even with only a couple ovens.

# Cause:
Previously every individual `OvenBlockEntity` created a new `fuelTimeMap` on every tick at least once, if not twice. This is a very expensive calculation, especially in modded Minecraft with many modded fuels added to the registry.

# Changes: 
Changed `canUseAsFuel` and `getFuelTime` to utilize Fabrics `FuelRegistry`, which caches the fuel map.

### Before
With about 12 ovens placed and spark ran for about 5 minutes:
![image](https://github.com/zombiecute/BakingDelight/assets/72876796/00920d19-6358-4486-8a1b-acca93cfcf49)

### After
same ovens, same profile run time in same world
![image](https://github.com/zombiecute/BakingDelight/assets/72876796/203c2524-5661-49e1-8497-e4e25f2c07e0)
